### PR TITLE
Issue #11: Support of static functions with varargs

### DIFF
--- a/src/main/java/org/glassfish/expressly/Messages.properties
+++ b/src/main/java/org/glassfish/expressly/Messages.properties
@@ -51,6 +51,7 @@ error.property.notfound=Property ''{1}'' not found on {0}
 error.fnMapper.null=Expression uses functions, but no FunctionMapper was provided
 error.fnMapper.method=Function ''{0}'' not found
 error.fnMapper.paramcount=Function ''{0}'' specifies {1} params, but {2} were supplied
+error.fnMapper.minparamcount=Function ''{0}'' requires at least {1} params, but {2} were supplied
 
 # **ExpressionImpl
 error.context.null=ELContext was null

--- a/src/main/java/org/glassfish/expressly/lang/ExpressionBuilder.java
+++ b/src/main/java/org/glassfish/expressly/lang/ExpressionBuilder.java
@@ -240,7 +240,12 @@ public final class ExpressionBuilder implements NodeVisitor {
 
             int parameterCount = functionMethod.getParameterCount();
             int argumentCount = ((AstMethodArguments) node.jjtGetChild(0)).getParameterCount();
-            if (argumentCount != parameterCount) {
+            if(functionMethod.isVarArgs()) {
+                // last param of the method is the vararg -> 0..n vararg-arguments allowed
+                if (argumentCount < parameterCount - 1) {
+                    throw new ELException(MessageFactory.get("error.fnMapper.minparamcount", funcNode.getOutputName(), parameterCount - 1, argumentCount));
+                }
+            } else if (argumentCount != parameterCount) {
                 throw new ELException(MessageFactory.get("error.fnMapper.paramcount", funcNode.getOutputName(), parameterCount, argumentCount));
             }
         } else if (node instanceof AstIdentifier && varMapper != null) {

--- a/src/main/java/org/glassfish/expressly/parser/AstFunction.java
+++ b/src/main/java/org/glassfish/expressly/parser/AstFunction.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Method;
 
 import org.glassfish.expressly.lang.EvaluationContext;
 import org.glassfish.expressly.util.MessageFactory;
+import org.glassfish.expressly.util.ReflectionUtil;
 
 import jakarta.el.ELClass;
 import jakarta.el.ELException;
@@ -167,12 +168,11 @@ public final class AstFunction extends SimpleNode {
         Class<?>[] paramTypes = functionMethod.getParameterTypes();
         Object[] params = ((AstMethodArguments) this.children[0]).getParameters(ctx);
         Object result = null;
-        for (int i = 0; i < params.length; i++) {
-            try {
-                params[i] = ctx.convertToType(params[i], paramTypes[i]);
-            } catch (ELException ele) {
-                throw new ELException(MessageFactory.get("error.function", this.getOutputName()), ele);
-            }
+        try {
+            params = ReflectionUtil.buildParameters(ctx, paramTypes, functionMethod.isVarArgs(), params);
+        }
+        catch(ELException ele) {
+            throw new ELException(MessageFactory.get("error.function", this.getOutputName()), ele);
         }
 
         try {

--- a/src/main/java/org/glassfish/expressly/util/ReflectionUtil.java
+++ b/src/main/java/org/glassfish/expressly/util/ReflectionUtil.java
@@ -655,7 +655,8 @@ public class ReflectionUtil {
                 }
 
                 // Last parameter is the varargs
-                if (parameterTypes.length == paramCount && parameterTypes[varArgIndex] == params[varArgIndex].getClass()) {
+                if (parameterTypes.length == paramCount &&
+                    (params[varArgIndex] == null || parameterTypes[varArgIndex] == params[varArgIndex].getClass())) {
                     parameters[varArgIndex] = params[varArgIndex];
                 } else {
                     Class<?> varArgClass = parameterTypes[varArgIndex].getComponentType();

--- a/src/test/java/org/glassfish/el/test/ELProcessorTest.java
+++ b/src/test/java/org/glassfish/el/test/ELProcessorTest.java
@@ -26,10 +26,12 @@ import static org.junit.Assert.assertTrue;
 
 import jakarta.el.ELProcessor;
 import jakarta.el.ELManager;
+import jakarta.el.ELException;
 import jakarta.el.ExpressionFactory;
 import jakarta.el.MethodExpression;
 import jakarta.el.ELContext;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 
 public class ELProcessorTest {
 
@@ -160,6 +162,61 @@ public class ELProcessorTest {
         }
         assertTrue(caught);
     }
+
+    @Test
+    public void defineVarargFuncTest()
+    {
+        Class<?> c = MyBean.class;
+        Method meth1 = null;
+        Method meth2 = null;
+        try {
+            meth1 = c.getMethod("join", new Class<?>[] {String[].class});
+            meth2 = c.getMethod("joinPrefixed", new Class<?>[] {String.class, String[].class});
+        } catch(Exception e) {
+            System.out.printf("Exception: ", e);
+        }
+        try {
+            elp.defineFunction("xx", "", meth1);
+            String joined = elp.eval("xx:join()");
+            assertEquals("", joined);
+            joined = elp.eval("xx:join('abc')");
+            assertEquals("abc", joined);
+            joined = elp.eval("xx:join('abc','def')");
+            assertEquals("abc,def", joined);
+            joined = elp.eval("xx:join('abc',null)"); // null is converted to empty string
+            assertEquals("abc,", joined);
+            joined = elp.eval("xx:join(null)"); // this is join((String[])null) in Java
+            assertEquals("<null array>", joined);
+        } catch(NoSuchMethodException ex) {
+
+        }
+
+        boolean caught = false;
+        try {
+            elp.defineFunction("xx", "", meth2);
+            Integer sum = elp.eval("xx:joinPrefixed()");
+            assertEquals(0, sum.intValue());
+        } catch (ELException ex) {
+            caught = true;
+        } catch (NoSuchMethodException ex) {
+
+        }
+        assertTrue(caught);
+
+        try {
+            elp.defineFunction("xx", "", meth2);
+            String joined = elp.eval("xx:joinPrefixed('res:')");
+            assertEquals("res:", joined);
+            joined = elp.eval("xx:joinPrefixed('res:', 'abc')");
+            assertEquals("res:abc", joined);
+            joined = elp.eval("xx:joinPrefixed('res:', 'abc', 'def')");
+            assertEquals("res:abc,def", joined);
+            joined = elp.eval("xx:joinPrefixed('res:', null)");
+            assertEquals("res:<null array>", joined);
+        } catch(NoSuchMethodException ex) {
+
+        }
+    }
 /*
     @Test
     public void testBean() {
@@ -199,6 +256,15 @@ public class ELProcessorTest {
         }
         public static int getBar() {
             return 64;
+        }
+        public static String join(String... args) {
+            if(args == null)
+                return "<null array>";
+
+            return String.join(",", args);
+        }
+        public static String joinPrefixed(String prefix, String... args) {
+            return prefix + join(args);
         }
     }
 }


### PR DESCRIPTION
Validating vararg-functions allow dynamic parameter count and invoking vararg-functions uses the existing parameter-resolution which already supports varargs.

I put it into the 5.0.0 branch, because I need this change for Java 11.